### PR TITLE
加入指令帮助列表、美化README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+</div>
+
+<div align="center">
+
+# astrbot_plugin_AnimeWife
+
+_✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 群老婆插件 ✨_
+
+[![Python 3.8+](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/)
+[![GitHub](https://img.shields.io/badge/作者-Futureppo-blue)](https://github.com/Futureppo)
+[![GitHub](https://img.shields.io/badge/作者-Zhalslar-blue)](https://github.com/Zhalslar)
+
+</div>
+
 ## 写在前面 ##
 - 灵感取自 [https://github.com/Rinco304/AnimeWife](https://github.com/Rinco304/AnimeWife)
 
@@ -16,19 +30,26 @@ gayhub不怎么会玩，不知道怎么设置，导致下载插件会下载relea
 - 增加了`老婆图鉴` 功能
 - 增加了`老婆图鉴` 功能，之前的指令替换为`群老婆图鉴`（本来没打算做这个的，谁让之前写的出bug了呢），把原来图鉴图片生成方式修改，提高图鉴生成速度（第一次生成可能依旧需要时间
 - 修复牛老婆数据被破坏导致无法牛的问题
-## 指令 ##
-- `抽老婆` 每天一次，随机抽一张二次元老婆
-- `查老婆` 查看今日老婆 加@可以查看别人老婆
-- `老婆图鉴` 查看已经解锁的老婆
-- `群老婆图鉴` 查看群里已经解锁的老婆
-- `切换ntr状态` 嗯.....
-- `牛老婆` 嗯.......
+- 加入指令查看、初步格式化代码
+## ⌨️ 命令
+
+|     命令      |      说明        |
+|:-------------:|:------------------------------------:|
+|   抽取老婆        | 每天一次，随机抽一张二次元老婆  |
+|   查老婆          | 看今日老婆 加@可以查看别人老婆  |
+|   老婆图鉴        | 看已经解锁的老婆    |
+|   群老婆图鉴      | 查看群里已经解锁的老婆 |
+|   切换ntr状态     | 嗯....... |
+|   牛老婆          | 嗯....... |
+
 ## 更新计划 ##
 - 1.6 `用户档案` 统计用户在群内抽取/牛/收集/被牛/次数
 - 1.7 好感度或者issues里说的玩老婆功能？不过不会那么露骨
 - 1.8 `老婆档案` 某个老婆的相遇时间（解锁时间）抽取次数好感度等
 
+## 🌟 支持
 
+- Star 这个项目！
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 群老婆插件 ✨_
 
 [![Python 3.8+](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/)
-[![GitHub](https://img.shields.io/badge/作者-Futureppo-blue)](https://github.com/zgojin)
+[![GitHub](https://img.shields.io/badge/作者-zgojin-blue)](https://github.com/zgojin)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 群老婆插件 ✨_
 
 [![Python 3.8+](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/)
-[![GitHub](https://img.shields.io/badge/作者-Futureppo-blue)](https://github.com/Futureppo)
-[![GitHub](https://img.shields.io/badge/作者-Zhalslar-blue)](https://github.com/Zhalslar)
+[![GitHub](https://img.shields.io/badge/作者-Futureppo-blue)](https://github.com/zgojin)
 
 </div>
 

--- a/anime_wife_collage.py
+++ b/anime_wife_collage.py
@@ -1,8 +1,9 @@
-import os
 import json
+import os
 import time
-from PIL import Image, ImageOps, ImageDraw
-from typing import List, Dict, Set
+from typing import List, Set  # Dict未使用，故去除，不影响整体效果
+
+from PIL import Image, ImageDraw, ImageOps
 
 # 最大保留天数
 MAX_GALLERY_AGE = 7  # 保留7天内的图鉴
@@ -11,7 +12,7 @@ MAX_GALLERY_AGE = 7  # 保留7天内的图鉴
 def get_all_wife_images(img_dir: str) -> List[str]:
     """获取所有二次元老婆图片文件名"""
     if os.path.exists(img_dir):
-        image_extensions = ('.png', '.jpg', '.jpeg', '.gif', '.bmp')
+        image_extensions = (".png", ".jpg", ".jpeg", ".gif", ".bmp")
         return [f for f in os.listdir(img_dir) if f.lower().endswith(image_extensions)]
     return []
 
@@ -19,15 +20,17 @@ def get_all_wife_images(img_dir: str) -> List[str]:
 def get_unlocked_wives(group_id: str, config_dir: str) -> Set[str]:
     """获取指定群组中所有已解锁的老婆图片名"""
     unlocked = set()
-    config_file = os.path.join(config_dir, f'{group_id}.json')
+    config_file = os.path.join(config_dir, f"{group_id}.json")
 
     if os.path.exists(config_file):
-        with open(config_file, 'r', encoding='utf-8') as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             try:
                 config = json.load(f)
                 for user_data in config.values():
-                    if isinstance(user_data, dict) and 'unlocked' in user_data:
-                        unlocked.update([item["wife_name"] for item in user_data["unlocked"]])
+                    if isinstance(user_data, dict) and "unlocked" in user_data:
+                        unlocked.update(
+                            [item["wife_name"] for item in user_data["unlocked"]]
+                        )
             except json.JSONDecodeError:
                 print(f"解析配置文件 {config_file} 时出错")
 
@@ -35,9 +38,7 @@ def get_unlocked_wives(group_id: str, config_dir: str) -> Set[str]:
 
 
 def create_full_color_gallery(
-    img_dir: str,
-    output_path: str,
-    thumbnail_size: tuple = (80, 80)
+    img_dir: str, output_path: str, thumbnail_size: tuple = (80, 80)
 ) -> None:
     """创建全彩色的老婆图鉴（通用版）"""
     all_wives = get_all_wife_images(img_dir)
@@ -52,7 +53,7 @@ def create_full_color_gallery(
 
     collage_width = cols * thumbnail_size[0]
     collage_height = rows * thumbnail_size[1]
-    collage = Image.new('RGB', (collage_width, collage_height), (245, 245, 245))
+    collage = Image.new("RGB", (collage_width, collage_height), (245, 245, 245))
     draw = ImageDraw.Draw(collage)
 
     # 处理所有图片为彩色
@@ -66,32 +67,38 @@ def create_full_color_gallery(
         try:
             with Image.open(img_path) as img:
                 # 处理透明背景
-                if img.mode in ('RGBA', 'LA'):
+                if img.mode in ("RGBA", "LA"):
                     background = Image.new(img.mode[:-1], img.size, (255, 255, 255))
                     background.paste(img, mask=img.split()[-1])
                     img = background
-                elif img.mode == 'P':
-                    img = img.convert('RGB')
+                elif img.mode == "P":
+                    img = img.convert("RGB")
 
                 # 缩放图片
                 img.thumbnail(thumbnail_size)
 
                 # 创建固定尺寸的缩略图
-                thumb = Image.new('RGB', thumbnail_size, (255, 255, 255))
-                offset = ((thumbnail_size[0] - img.width) // 2, (thumbnail_size[1] - img.height) // 2)
+                thumb = Image.new("RGB", thumbnail_size, (255, 255, 255))
+                offset = (
+                    (thumbnail_size[0] - img.width) // 2,
+                    (thumbnail_size[1] - img.height) // 2,
+                )
                 thumb.paste(img, offset)
 
                 # 保持彩色
                 collage.paste(thumb, (x, y))
         except:
             # 出错时绘制默认彩色方块
-            draw.rectangle([(x, y), (x + thumbnail_size[0], y + thumbnail_size[1])], fill=(220, 220, 220))
+            draw.rectangle(
+                [(x, y), (x + thumbnail_size[0], y + thumbnail_size[1])],
+                fill=(220, 220, 220),
+            )
 
         # 绘制边框
         draw.rectangle(
             [(x, y), (x + thumbnail_size[0] - 1, y + thumbnail_size[1] - 1)],
             outline=(200, 200, 200),
-            width=1
+            width=1,
         )
 
     # 保存彩色大图
@@ -105,7 +112,7 @@ def update_gallery_with_black_and_white(
     config_dir: str,
     color_gallery_path: str,
     output_path: str,
-    thumbnail_size: tuple = (80, 80)
+    thumbnail_size: tuple = (80, 80),
 ) -> None:
     """在通用彩色大图上渲染未解锁的黑白图片"""
     all_wives = sorted(get_all_wife_images(img_dir))  # 确保顺序固定
@@ -130,7 +137,9 @@ def update_gallery_with_black_and_white(
                 y = row * thumbnail_size[1]
 
                 # 提取对应位置的彩色图块
-                block = gallery.crop((x, y, x + thumbnail_size[0], y + thumbnail_size[1]))
+                block = gallery.crop(
+                    (x, y, x + thumbnail_size[0], y + thumbnail_size[1])
+                )
 
                 # 将图块转换为灰度图
                 block = ImageOps.grayscale(block)
@@ -144,7 +153,9 @@ def update_gallery_with_black_and_white(
         title_height = title_font_size + 10
 
         # 创建一个更高的新画布，包含标题区域
-        new_collage = Image.new('RGB', (gallery.width, gallery.height + title_height), (245, 245, 245))
+        new_collage = Image.new(
+            "RGB", (gallery.width, gallery.height + title_height), (245, 245, 245)
+        )
         new_draw = ImageDraw.Draw(new_collage)
 
         # 粘贴原拼贴图到新画布
@@ -159,7 +170,9 @@ def update_gallery_with_black_and_white(
 
 
 # 清理旧图鉴文件
-def cleanup_old_galleries(gallery_dir: str, max_age_days: int = MAX_GALLERY_AGE) -> None:
+def cleanup_old_galleries(
+    gallery_dir: str, max_age_days: int = MAX_GALLERY_AGE
+) -> None:
     """清理超过指定天数的图鉴文件"""
     if not os.path.exists(gallery_dir):
         return
@@ -170,7 +183,7 @@ def cleanup_old_galleries(gallery_dir: str, max_age_days: int = MAX_GALLERY_AGE)
     for filename in os.listdir(gallery_dir):
         file_path = os.path.join(gallery_dir, filename)
         # 只处理图片文件
-        if filename.lower().endswith(('.png', '.jpg', '.jpeg')):
+        if filename.lower().endswith((".png", ".jpg", ".jpeg")):
             try:
                 # 获取文件修改时间
                 mtime = os.path.getmtime(file_path)
@@ -188,7 +201,7 @@ def create_or_update_wife_gallery(
     config_dir: str,
     color_gallery_dir: str,
     output_path: str,
-    thumbnail_size: tuple = (80, 80)
+    thumbnail_size: tuple = (80, 80),
 ) -> str:
     """
     检查并生成老婆图鉴：
@@ -201,14 +214,16 @@ def create_or_update_wife_gallery(
     cleanup_old_galleries(gallery_dir)
 
     # 通用彩色大图路径
-    common_color_gallery_path = os.path.join(color_gallery_dir, 'common_color_gallery.png')
+    common_color_gallery_path = os.path.join(
+        color_gallery_dir, "common_color_gallery.png"
+    )
 
     # 检查通用彩色大图是否存在，不存在则生成
     if not os.path.exists(common_color_gallery_path):
         create_full_color_gallery(
             img_dir=img_dir,
             output_path=common_color_gallery_path,
-            thumbnail_size=thumbnail_size
+            thumbnail_size=thumbnail_size,
         )
 
     # 在通用彩色大图上渲染未解锁的黑白图片
@@ -218,16 +233,17 @@ def create_or_update_wife_gallery(
         config_dir=config_dir,
         color_gallery_path=common_color_gallery_path,
         output_path=output_path,
-        thumbnail_size=thumbnail_size
+        thumbnail_size=thumbnail_size,
     )
 
     return output_path
+
 
 def create_personal_wife_gallery(
     unlocked_wives: List[str],
     img_dir: str,
     output_path: str,
-    thumbnail_size: tuple = (80, 80)
+    thumbnail_size: tuple = (80, 80),
 ) -> str:
     """创建个人老婆图鉴"""
     if not unlocked_wives:
@@ -241,7 +257,7 @@ def create_personal_wife_gallery(
 
     collage_width = cols * thumbnail_size[0]
     collage_height = rows * thumbnail_size[1]
-    collage = Image.new('RGB', (collage_width, collage_height), (245, 245, 245))
+    collage = Image.new("RGB", (collage_width, collage_height), (245, 245, 245))
     draw = ImageDraw.Draw(collage)
 
     for i, wife in enumerate(unlocked_wives):
@@ -254,32 +270,38 @@ def create_personal_wife_gallery(
         try:
             with Image.open(img_path) as img:
                 # 处理透明背景
-                if img.mode in ('RGBA', 'LA'):
+                if img.mode in ("RGBA", "LA"):
                     background = Image.new(img.mode[:-1], img.size, (255, 255, 255))
                     background.paste(img, mask=img.split()[-1])
                     img = background
-                elif img.mode == 'P':
-                    img = img.convert('RGB')
+                elif img.mode == "P":
+                    img = img.convert("RGB")
 
                 # 缩放图片
                 img.thumbnail(thumbnail_size)
 
                 # 创建固定尺寸的缩略图
-                thumb = Image.new('RGB', thumbnail_size, (255, 255, 255))
-                offset = ((thumbnail_size[0] - img.width) // 2, (thumbnail_size[1] - img.height) // 2)
+                thumb = Image.new("RGB", thumbnail_size, (255, 255, 255))
+                offset = (
+                    (thumbnail_size[0] - img.width) // 2,
+                    (thumbnail_size[1] - img.height) // 2,
+                )
                 thumb.paste(img, offset)
 
                 # 保持彩色
                 collage.paste(thumb, (x, y))
         except:
             # 出错时绘制默认彩色方块
-            draw.rectangle([(x, y), (x + thumbnail_size[0], y + thumbnail_size[1])], fill=(220, 220, 220))
+            draw.rectangle(
+                [(x, y), (x + thumbnail_size[0], y + thumbnail_size[1])],
+                fill=(220, 220, 220),
+            )
 
         # 绘制边框
         draw.rectangle(
             [(x, y), (x + thumbnail_size[0] - 1, y + thumbnail_size[1] - 1)],
             outline=(200, 200, 200),
-            width=1
+            width=1,
         )
 
     # 保存个人图鉴

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import requests
 from astrbot.api.all import *
 from astrbot.api.event import filter
+from astrbot.api.event.filter import EventMessageType  # 新增导入
 
 # 设置插件主目录
 PLUGIN_DIR = os.path.join("data", "plugins", "astrbot_plugin_AnimeWife")
@@ -261,16 +262,13 @@ class WifePlugin(Star):
                             pass
         return None
 
-    @event_message_type(EventMessageType.ALL)
-    async def on_all_messages(self, event: AstrMessageEvent):
-        """消息处理入口，进行群聊检查"""
-        # 检查是否为群聊消息，其他消息不处理
-        if not hasattr(event.message_obj, "group_id"):
-            return
-
-    @filter.command("抽取老婆")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def animewife(self, event: AstrMessageEvent):
         """随机抽取一张二次元老婆"""
+        # 检查消息是否包含指令关键词
+        if "抽取老婆" not in event.message_str.strip():
+            return
+
         group_id = event.message_obj.group_id
         if not group_id:
             return
@@ -361,9 +359,13 @@ class WifePlugin(Star):
         # 保存配置
         write_group_config(group_id, config)
 
-    @filter.command("牛老婆")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def ntr_wife(self, event: AstrMessageEvent):
         """牛老婆 @user"""
+        # 检查消息是否包含指令关键词
+        if not event.message_str.strip().startswith("牛老婆"):
+            return
+
         group_id = str(event.message_obj.group_id)
         if not group_id:
             yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
@@ -448,9 +450,13 @@ class WifePlugin(Star):
                 f"{nickname}，你的NTR计划失败了，还剩{remaining}次机会~"
             )
 
-    @filter.command("查老婆")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def search_wife(self, event: AstrMessageEvent):
         """查老婆 @user"""
+        # 检查消息是否包含指令关键词
+        if not event.message_str.strip().startswith("查老婆"):
+            return
+
         group_id = event.message_obj.group_id
         if not group_id:
             yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
@@ -514,9 +520,13 @@ class WifePlugin(Star):
         except:
             yield event.plain_result(text_message)
 
-    @filter.command("切换ntr状态")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def switch_ntr(self, event: AstrMessageEvent):
         """切换是否进入NTR状态"""
+        # 检查消息是否匹配指令
+        if event.message_str.strip() != "切换ntr状态":
+            return
+
         group_id = str(event.message_obj.group_id)
         if not group_id:
             yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
@@ -538,9 +548,13 @@ class WifePlugin(Star):
         status_text = "开启" if ntr_statuses[group_id] else "关闭"
         yield event.plain_result(f"NTR功能已{status_text}，请注意群内和谐~")
 
-    @filter.command("群老婆图鉴")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def show_group_wife_gallery(self, event: AstrMessageEvent):
         """查看群里已经解锁的老婆"""
+        # 检查消息是否匹配指令
+        if event.message_str.strip() != "群老婆图鉴":
+            return
+
         group_id = event.message_obj.group_id
         if not group_id:
             yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
@@ -604,9 +618,13 @@ class WifePlugin(Star):
             print(f"生成图鉴失败: {e}")
             yield event.plain_result("生成图鉴失败，请稍后再试。")
 
-    @filter.command("老婆图鉴")
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE)
     async def show_personal_wife_gallery(self, event: AstrMessageEvent):
         """查看已经解锁的老婆"""
+        # 检查消息是否匹配指令
+        if event.message_str.strip() != "老婆图鉴":
+            return
+
         group_id = event.message_obj.group_id
         if not group_id:
             yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 import requests
 from astrbot.api.all import *
 from astrbot.api.event import filter
-from astrbot.api.event.filter import EventMessageType  # 新增导入
 
 # 设置插件主目录
 PLUGIN_DIR = os.path.join("data", "plugins", "astrbot_plugin_AnimeWife")

--- a/main.py
+++ b/main.py
@@ -212,20 +212,12 @@ def get_unlock_date(unlocked, wife_name):
     "wife_plugin",
     "长安某",
     "二次元老婆抽卡与图鉴插件",
-    "1.5.2",
+    "1.5.3",
     "https://github.com/zgojin/astrbot_plugin_AW",
 )
 class WifePlugin(Star):
     def __init__(self, context: Context):
         super().__init__(context)
-        self.commands = {
-            "抽老婆": self.animewife,
-            "牛老婆": self.ntr_wife,
-            "查老婆": self.search_wife,
-            "切换ntr状态": self.switch_ntr,
-            "群老婆图鉴": self.show_group_wife_gallery,
-            "老婆图鉴": self.show_personal_wife_gallery,
-        }
         self.admins = self.load_admins()
 
     def load_admins(self):
@@ -271,19 +263,10 @@ class WifePlugin(Star):
 
     @event_message_type(EventMessageType.ALL)
     async def on_all_messages(self, event: AstrMessageEvent):
-        """消息处理入口，检查并执行匹配的命令"""
-        # 检查是否为群聊消息
+        """消息处理入口，进行群聊检查"""
+        # 检查是否为群聊消息，其他消息不处理
         if not hasattr(event.message_obj, "group_id"):
             return
-
-        group_id = event.message_obj.group_id
-        message_str = event.message_str.strip()
-
-        for command, func in self.commands.items():
-            if command in message_str:
-                async for result in func(event):
-                    yield result
-                break
 
     @filter.command("抽取老婆")
     async def animewife(self, event: AstrMessageEvent):

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 
 import requests
 from astrbot.api.all import *
+from astrbot.api.event import filter
 
 # 设置插件主目录
 PLUGIN_DIR = os.path.join("data", "plugins", "astrbot_plugin_AnimeWife")

--- a/main.py
+++ b/main.py
@@ -1,43 +1,43 @@
-from astrbot.api.all import *
-from datetime import datetime, timedelta
-import random
-import os
-import re
-import json
-import requests
-from concurrent.futures import ThreadPoolExecutor
 import asyncio
-from io import BytesIO
+import json
+import os
+import random
+import re
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+
+import requests
+from astrbot.api.all import *
 
 # 设置插件主目录
-PLUGIN_DIR = os.path.join('data', 'plugins', 'astrbot_plugin_AnimeWife')
+PLUGIN_DIR = os.path.join("data", "plugins", "astrbot_plugin_AnimeWife")
 os.makedirs(PLUGIN_DIR, exist_ok=True)
 
 # 配置文件目录
-CONFIG_DIR = os.path.join(PLUGIN_DIR, 'config')
+CONFIG_DIR = os.path.join(PLUGIN_DIR, "config")
 os.makedirs(CONFIG_DIR, exist_ok=True)
 
 # 本地图片目录
-IMG_DIR = os.path.join(PLUGIN_DIR, 'img', 'wife')
+IMG_DIR = os.path.join(PLUGIN_DIR, "img", "wife")
 os.makedirs(IMG_DIR, exist_ok=True)
 
 # 黑白大图目录
-BW_GALLERY_DIR = os.path.join(PLUGIN_DIR, 'bw_galleries')
+BW_GALLERY_DIR = os.path.join(PLUGIN_DIR, "bw_galleries")
 os.makedirs(BW_GALLERY_DIR, exist_ok=True)
 # 通用黑白大图路径（所有群共用）
-COMMON_BW_GALLERY_PATH = os.path.join(BW_GALLERY_DIR, 'common_bw_gallery.png')
+COMMON_BW_GALLERY_PATH = os.path.join(BW_GALLERY_DIR, "common_bw_gallery.png")
 
 # 最终图鉴目录
-GALLERY_DIR = os.path.join(PLUGIN_DIR, 'gallery')
+GALLERY_DIR = os.path.join(PLUGIN_DIR, "gallery")
 os.makedirs(GALLERY_DIR, exist_ok=True)
 
 # NTR 状态文件路径
-NTR_STATUS_FILE = os.path.join(CONFIG_DIR, 'ntr_status.json')
+NTR_STATUS_FILE = os.path.join(CONFIG_DIR, "ntr_status.json")
 # NTR 次数限制文件路径
-NTR_LIMIT_FILE = os.path.join(CONFIG_DIR, 'ntr_limit.json')
+NTR_LIMIT_FILE = os.path.join(CONFIG_DIR, "ntr_limit.json")
 
 # 图片的基础 URL
-IMAGE_BASE_URL = 'http://save.my996.top/?/img/'
+IMAGE_BASE_URL = "http://save.my996.top/?/img/"
 
 # 创建线程池用于异步处理
 executor = ThreadPoolExecutor(max_workers=2)
@@ -49,7 +49,8 @@ ntr_possibility = 0.20
 
 # 全局NTR数据
 ntr_statuses = {}  # NTR功能开关状态
-ntr_limits = {}    # NTR次数限制，按群、用户、日期记录
+ntr_limits = {}  # NTR次数限制，按群、用户、日期记录
+
 
 def clean_old_ntr_data():
     """清理非当天的NTR计数数据，只保留今日记录"""
@@ -71,25 +72,26 @@ def clean_old_ntr_data():
         if not group_data:
             del ntr_limits[group_id]
 
+
 def load_ntr_data():
     """加载NTR状态和次数限制数据，并清理历史记录"""
     global ntr_statuses, ntr_limits
     ntr_statuses = {}
     ntr_limits = {}
-    
+
     # 加载NTR状态
     if os.path.exists(NTR_STATUS_FILE):
         try:
-            with open(NTR_STATUS_FILE, 'r', encoding='utf-8') as f:
+            with open(NTR_STATUS_FILE, "r", encoding="utf-8") as f:
                 ntr_statuses = json.load(f)
         except Exception as e:
             print(f"加载NTR状态失败: {e}")
             ntr_statuses = {}
-    
+
     # 加载NTR次数限制
     if os.path.exists(NTR_LIMIT_FILE):
         try:
-            with open(NTR_LIMIT_FILE, 'r', encoding='utf-8') as f:
+            with open(NTR_LIMIT_FILE, "r", encoding="utf-8") as f:
                 ntr_limits = json.load(f)
                 # 兼容处理：升级旧格式数据
                 ntr_limits = _upgrade_ntr_limit_format(ntr_limits)
@@ -102,18 +104,20 @@ def load_ntr_data():
     # 关键：加载后清理历史数据，只保留当天计数
     clean_old_ntr_data()
 
+
 def save_ntr_data():
     """保存NTR状态和次数限制数据"""
     try:
         # 保存NTR状态
-        with open(NTR_STATUS_FILE, 'w', encoding='utf-8') as f:
+        with open(NTR_STATUS_FILE, "w", encoding="utf-8") as f:
             json.dump(ntr_statuses, f, ensure_ascii=False, indent=2)
-        
+
         # 保存NTR次数限制
-        with open(NTR_LIMIT_FILE, 'w', encoding='utf-8') as f:
+        with open(NTR_LIMIT_FILE, "w", encoding="utf-8") as f:
             json.dump(ntr_limits, f, ensure_ascii=False, indent=2)
     except Exception as e:
         print(f"保存NTR数据失败: {e}")
+
 
 def _upgrade_ntr_limit_format(data):
     """
@@ -153,11 +157,13 @@ def _upgrade_ntr_limit_format(data):
         new_data[group_id] = new_group_data
     return new_data
 
+
 def get_today():
     """获取上海时区当日日期"""
     utc_now = datetime.utcnow()
     shanghai_time = utc_now + timedelta(hours=8)
     return shanghai_time.date().isoformat()
+
 
 def parse_wife_name(wife_name: str) -> (str, str):
     """
@@ -166,7 +172,7 @@ def parse_wife_name(wife_name: str) -> (str, str):
     1. 来源.角色名.jpg
     2. 角色名.jpg/png
     """
-    parts = wife_name.split('.')
+    parts = wife_name.split(".")
     if len(parts) >= 3:
         # 新格式：来源.角色名.jpg
         source = parts[0]
@@ -174,17 +180,22 @@ def parse_wife_name(wife_name: str) -> (str, str):
     else:
         # 旧格式：角色名.jpg/png 或 角色名.png
         name = parts[0]
-        source = '未知'
+        source = "未知"
     return name, source
+
 
 def upgrade_unlocked_format(unlocked_list):
     """将旧格式的 unlocked 列表转换为包含解锁时间的对象数组"""
     today = get_today()
     return [{"wife_name": wife, "unlock_date": today} for wife in unlocked_list]
 
+
 def get_wife_names_from_unlocked(unlocked):
     """从解锁列表中提取老婆名字列表"""
-    return [item["wife_name"] for item in unlocked] if isinstance(unlocked, list) else []
+    return (
+        [item["wife_name"] for item in unlocked] if isinstance(unlocked, list) else []
+    )
+
 
 def get_unlock_date(unlocked, wife_name):
     """获取指定老婆的解锁时间"""
@@ -195,7 +206,14 @@ def get_unlock_date(unlocked, wife_name):
             return item.get("unlock_date")
     return None
 
-@register("wife_plugin", "长安某", "二次元老婆抽卡与图鉴插件", "1.5.1", "https://github.com/zgojin/astrbot_plugin_AW")
+
+@register(
+    "wife_plugin",
+    "长安某",
+    "二次元老婆抽卡与图鉴插件",
+    "1.5.2",
+    "https://github.com/zgojin/astrbot_plugin_AW",
+)
 class WifePlugin(Star):
     def __init__(self, context: Context):
         super().__init__(context)
@@ -205,16 +223,18 @@ class WifePlugin(Star):
             "查老婆": self.search_wife,
             "切换ntr状态": self.switch_ntr,
             "群老婆图鉴": self.show_group_wife_gallery,
-            "老婆图鉴": self.show_personal_wife_gallery
+            "老婆图鉴": self.show_personal_wife_gallery,
         }
         self.admins = self.load_admins()
 
     def load_admins(self):
         """加载管理员列表"""
         try:
-            with open(os.path.join('data', 'cmd_config.json'), 'r', encoding='utf-8-sig') as f:
+            with open(
+                os.path.join("data", "cmd_config.json"), "r", encoding="utf-8-sig"
+            ) as f:
                 config = json.load(f)
-                return config.get('admins_id', [])
+                return config.get("admins_id", [])
         except:
             return []
 
@@ -232,7 +252,7 @@ class WifePlugin(Star):
             return target_id
         msg = event.message_str.strip()
         if msg.startswith(("牛老婆", "查老婆")):
-            target_name = msg[len(msg.split()[0]):].strip()
+            target_name = msg[len(msg.split()[0]) :].strip()
             if target_name:
                 group_id = str(event.message_obj.group_id)
                 config = load_group_config(group_id)
@@ -240,7 +260,9 @@ class WifePlugin(Star):
                     for user_id, user_data in config.items():
                         try:
                             nick_name = event.get_sender_name() or "未知用户"
-                            if re.search(re.escape(target_name), nick_name, re.IGNORECASE):
+                            if re.search(
+                                re.escape(target_name), nick_name, re.IGNORECASE
+                            ):
                                 return user_id
                         except:
                             pass
@@ -262,8 +284,9 @@ class WifePlugin(Star):
                     yield result
                 break
 
+    @filter.command("抽取老婆")
     async def animewife(self, event: AstrMessageEvent):
-        """抽老婆功能实现"""
+        """随机抽取一张二次元老婆"""
         group_id = event.message_obj.group_id
         if not group_id:
             return
@@ -272,7 +295,7 @@ class WifePlugin(Star):
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请检查消息事件对象。')
+            yield event.plain_result("无法获取用户信息，请检查消息事件对象。")
             return
 
         wife_name = None
@@ -284,7 +307,7 @@ class WifePlugin(Star):
             config[str(user_id)] = {
                 "current": {"wife_name": None, "date": ""},
                 "unlocked": [],
-                "nickname": nickname
+                "nickname": nickname,
             }
         user_data = config[str(user_id)]
 
@@ -303,34 +326,35 @@ class WifePlugin(Star):
                         image_list = response.text.splitlines()
                         wife_name = random.choice(image_list) if image_list else None
                     if not wife_name:
-                        yield event.plain_result('图片列表为空，请稍后再试。')
+                        yield event.plain_result("图片列表为空，请稍后再试。")
                         return
                 except:
-                    yield event.plain_result('获取图片时发生错误，请稍后再试。')
+                    yield event.plain_result("获取图片时发生错误，请稍后再试。")
                     return
 
             # 更新当日老婆
-            user_data["current"] = {
-                "wife_name": wife_name,
-                "date": today
-            }
+            user_data["current"] = {"wife_name": wife_name, "date": today}
 
             # 记录历史解锁（去重）
             unlocked_wives = get_wife_names_from_unlocked(user_data["unlocked"])
             if wife_name and wife_name not in unlocked_wives:
-                user_data["unlocked"].append({"wife_name": wife_name, "unlock_date": today})
+                user_data["unlocked"].append(
+                    {"wife_name": wife_name, "unlock_date": today}
+                )
 
         # 解析并发送结果
         name, source = parse_wife_name(wife_name)
-        if source != '未知':
-            text_message = f'{nickname}，你今天的二次元老婆是来自《{source}》的{name}哒~ '
+        if source != "未知":
+            text_message = (
+                f"{nickname}，你今天的二次元老婆是来自《{source}》的{name}哒~ "
+            )
         else:
-            text_message = f'{nickname}，你今天的二次元老婆是{name}哒~'
+            text_message = f"{nickname}，你今天的二次元老婆是{name}哒~"
 
         try:
             # 尝试发送图片
             if os.path.exists(os.path.join(IMG_DIR, wife_name)):
-                with open(os.path.join(IMG_DIR, wife_name), 'rb') as f:
+                with open(os.path.join(IMG_DIR, wife_name), "rb") as f:
                     image_data = f.read()
                 chain = [Plain(text_message), Image.fromBytes(image_data)]
             else:
@@ -339,9 +363,11 @@ class WifePlugin(Star):
                 if response.status_code == 200:
                     chain = [Plain(text_message), Image.fromBytes(response.content)]
                 else:
-                    chain = [Plain(f'{text_message}\n图片加载失败，请检查图片链接是否有效。')]
+                    chain = [
+                        Plain(f"{text_message}\n图片加载失败，请检查图片链接是否有效。")
+                    ]
         except:
-            chain = [Plain(f'{text_message}\n图片加载失败，请稍后再试。')]
+            chain = [Plain(f"{text_message}\n图片加载失败，请稍后再试。")]
 
         try:
             yield event.chain_result(chain)
@@ -351,22 +377,23 @@ class WifePlugin(Star):
         # 保存配置
         write_group_config(group_id, config)
 
+    @filter.command("牛老婆")
     async def ntr_wife(self, event: AstrMessageEvent):
-        """NTR（抢老婆）功能实现"""
+        """牛老婆 @user"""
         group_id = str(event.message_obj.group_id)
         if not group_id:
-            yield event.plain_result('该功能仅支持群聊，请在群聊中使用。')
+            yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
             return
 
         if not ntr_statuses.get(group_id, False):
-            yield event.plain_result('NTR功能未开启！')
+            yield event.plain_result("NTR功能未开启！")
             return
 
         try:
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请检查消息事件对象。')
+            yield event.plain_result("无法获取用户信息，请检查消息事件对象。")
             return
 
         # 每次操作前强制刷新当天日期，避免跨天问题
@@ -375,68 +402,74 @@ class WifePlugin(Star):
         group_ntr = ntr_limits.setdefault(str(group_id), {})
         user_ntr = group_ntr.setdefault(user_id, {})
         today_count = user_ntr.get(today, 0)
-        
+
         if today_count >= _ntr_max:
-            yield event.plain_result(f'{nickname}，你今天已经牛了{_ntr_max}次，明日再来吧~')
+            yield event.plain_result(
+                f"{nickname}，你今天已经牛了{_ntr_max}次，明日再来吧~"
+            )
             return
 
         target_id = self.parse_target(event)
         if not target_id:
-            yield event.plain_result(f'{nickname}，请指定一个要下手的目标~')
+            yield event.plain_result(f"{nickname}，请指定一个要下手的目标~")
             return
 
         if user_id == target_id:
-            yield event.plain_result(f'{nickname}，不能对自己下手哦！')
+            yield event.plain_result(f"{nickname}，不能对自己下手哦！")
             return
 
         config = load_group_config(group_id)
         if not config:
-            yield event.plain_result('未找到本群婚姻登记信息~')
+            yield event.plain_result("未找到本群婚姻登记信息~")
             return
 
         if str(target_id) not in config:
-            yield event.plain_result('对方还没有老婆哦~')
+            yield event.plain_result("对方还没有老婆哦~")
             return
 
         target_data = config[str(target_id)]
         if target_data["current"]["date"] != today:
-            yield event.plain_result('对方的老婆已过期，换个目标吧~')
+            yield event.plain_result("对方的老婆已过期，换个目标吧~")
             return
 
         # 增加NTR次数并保存
         user_ntr[today] = today_count + 1
         save_ntr_data()
-        
+
         if random.random() < ntr_possibility:
             target_wife = target_data["current"]["wife_name"]
             # 更新当前用户的老婆
-            user_data = config.setdefault(str(user_id), {
-                "current": {"wife_name": None, "date": ""},
-                "unlocked": [],
-                "nickname": nickname
-            })
-            user_data["current"] = {
-                "wife_name": target_wife,
-                "date": today
-            }
+            user_data = config.setdefault(
+                str(user_id),
+                {
+                    "current": {"wife_name": None, "date": ""},
+                    "unlocked": [],
+                    "nickname": nickname,
+                },
+            )
+            user_data["current"] = {"wife_name": target_wife, "date": today}
             # 记录历史解锁
             unlocked_wives = get_wife_names_from_unlocked(user_data["unlocked"])
             if target_wife and target_wife not in unlocked_wives:
-                user_data["unlocked"].append({"wife_name": target_wife, "unlock_date": today})
+                user_data["unlocked"].append(
+                    {"wife_name": target_wife, "unlock_date": today}
+                )
             # 清除目标用户的当日老婆
             target_data["current"] = {"wife_name": None, "date": ""}
             write_group_config(group_id, config)
-            yield event.plain_result(f'{nickname}，恭喜你成功牛走了对方的老婆！')
+            yield event.plain_result(f"{nickname}，恭喜你成功牛走了对方的老婆！")
         else:
             remaining = _ntr_max - (today_count + 1)
             yield event.plain_result(
-                f'{nickname}，你的NTR计划失败了，还剩{remaining}次机会~')
+                f"{nickname}，你的NTR计划失败了，还剩{remaining}次机会~"
+            )
 
+    @filter.command("查老婆")
     async def search_wife(self, event: AstrMessageEvent):
-        """查询老婆信息功能实现"""
+        """查老婆 @user"""
         group_id = event.message_obj.group_id
         if not group_id:
-            yield event.plain_result('该功能仅支持群聊，请在群聊中使用。')
+            yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
             return
 
         target_id = self.parse_target(event)
@@ -446,19 +479,19 @@ class WifePlugin(Star):
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请检查消息事件对象。')
+            yield event.plain_result("无法获取用户信息，请检查消息事件对象。")
             return
 
         target_id = target_id or user_id
         config = load_group_config(group_id)
 
         if not config or str(target_id) not in config:
-            yield event.plain_result('未找到老婆信息！')
+            yield event.plain_result("未找到老婆信息！")
             return
 
         target_data = config[str(target_id)]
         if target_data["current"]["date"] != today:
-            yield event.plain_result('查询的老婆已过期~')
+            yield event.plain_result("查询的老婆已过期~")
             return
 
         wife_name = target_data["current"]["wife_name"]
@@ -469,15 +502,15 @@ class WifePlugin(Star):
         unlock_date = get_unlock_date(target_data["unlocked"], wife_name)
         unlock_info = f"（解锁于{unlock_date}）" if unlock_date else ""
 
-        if source != '未知':
-            text_message = f'{target_nickname}的二次元老婆是{name}哒~ 来自《{source}》{unlock_info}'
+        if source != "未知":
+            text_message = f"{target_nickname}的二次元老婆是{name}哒~ 来自《{source}》{unlock_info}"
         else:
-            text_message = f'{target_nickname}的二次元老婆是{name}哒~{unlock_info}'
+            text_message = f"{target_nickname}的二次元老婆是{name}哒~{unlock_info}"
 
         try:
             # 尝试发送图片
             if os.path.exists(os.path.join(IMG_DIR, wife_name)):
-                with open(os.path.join(IMG_DIR, wife_name), 'rb') as f:
+                with open(os.path.join(IMG_DIR, wife_name), "rb") as f:
                     image_data = f.read()
                 chain = [Plain(text_message), Image.fromBytes(image_data)]
             else:
@@ -486,63 +519,71 @@ class WifePlugin(Star):
                 if response.status_code == 200:
                     chain = [Plain(text_message), Image.fromBytes(response.content)]
                 else:
-                    chain = [Plain(f'{text_message}\n图片加载失败，请检查图片链接是否有效。')]
+                    chain = [
+                        Plain(f"{text_message}\n图片加载失败，请检查图片链接是否有效。")
+                    ]
         except:
-            chain = [Plain(f'{text_message}\n图片加载失败，请稍后再试。')]
+            chain = [Plain(f"{text_message}\n图片加载失败，请稍后再试。")]
 
         try:
             yield event.chain_result(chain)
         except:
             yield event.plain_result(text_message)
 
+    @filter.command("切换ntr状态")
     async def switch_ntr(self, event: AstrMessageEvent):
-        """切换NTR功能开关状态"""
+        """切换是否进入NTR状态"""
         group_id = str(event.message_obj.group_id)
         if not group_id:
-            yield event.plain_result('该功能仅支持群聊，请在群聊中使用。')
+            yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
             return
 
         try:
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请检查消息事件对象。')
+            yield event.plain_result("无法获取用户信息，请检查消息事件对象。")
             return
 
         if user_id not in self.admins:
-            yield event.plain_result(f'{nickname}，你没有权限切换NTR功能状态。')
+            yield event.plain_result(f"{nickname}，你没有权限切换NTR功能状态。")
             return
 
         ntr_statuses[group_id] = not ntr_statuses.get(group_id, False)
         save_ntr_data()
-        status_text = '开启' if ntr_statuses[group_id] else '关闭'
-        yield event.plain_result(f'NTR功能已{status_text}，请注意群内和谐~')
+        status_text = "开启" if ntr_statuses[group_id] else "关闭"
+        yield event.plain_result(f"NTR功能已{status_text}，请注意群内和谐~")
 
+    @filter.command("群老婆图鉴")
     async def show_group_wife_gallery(self, event: AstrMessageEvent):
-        """展示群老婆图鉴功能"""
+        """查看群里已经解锁的老婆"""
         group_id = event.message_obj.group_id
         if not group_id:
-            yield event.plain_result('该功能仅支持群聊，请在群聊中使用。')
+            yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
             return
 
         try:
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请重试。')
+            yield event.plain_result("无法获取用户信息，请重试。")
             return
 
         # 此处假设anime_wife_collage模块存在，实际使用时需确保该模块可用
         try:
-            from .anime_wife_collage import create_or_update_wife_gallery, get_all_wife_images, get_unlocked_wives
+            from .anime_wife_collage import (
+                create_or_update_wife_gallery,
+                get_all_wife_images,
+                get_unlocked_wives,
+            )
         except Exception as e:
             print(f"加载图鉴模块失败: {e}")
-            yield event.plain_result('老婆图鉴功能加载失败，请稍后再试。')
+            yield event.plain_result("老婆图鉴功能加载失败，请稍后再试。")
             return
 
         # 在后台线程中执行耗时的图鉴生成操作
         loop = asyncio.get_event_loop()
-        gallery_path = os.path.join(GALLERY_DIR, f'gallery_{group_id}.png')
+        gallery_path = os.path.join(GALLERY_DIR, f"gallery_{group_id}.png")
 
         try:
             gallery_path = await loop.run_in_executor(
@@ -552,12 +593,12 @@ class WifePlugin(Star):
                 IMG_DIR,
                 CONFIG_DIR,
                 BW_GALLERY_DIR,
-                gallery_path
+                gallery_path,
             )
 
             # 检查图片是否生成成功
             if not os.path.exists(gallery_path):
-                yield event.plain_result('图鉴生成失败，未找到图片文件。')
+                yield event.plain_result("图鉴生成失败，未找到图片文件。")
                 return
 
             # 获取已解锁数量和总数量
@@ -567,51 +608,56 @@ class WifePlugin(Star):
             total_count = len(all_wives)
 
             # 发送图鉴图片
-            with open(gallery_path, 'rb') as f:
+            with open(gallery_path, "rb") as f:
                 image_data = f.read()
 
-            msg = f'{nickname}，本群老婆图鉴来啦~ 已解锁: {unlocked_count}/{total_count}'
+            msg = (
+                f"{nickname}，本群老婆图鉴来啦~ 已解锁: {unlocked_count}/{total_count}"
+            )
             yield event.chain_result([Plain(msg), Image.fromBytes(image_data)])
 
         except Exception as e:
             print(f"生成图鉴失败: {e}")
-            yield event.plain_result('生成图鉴失败，请稍后再试。')
+            yield event.plain_result("生成图鉴失败，请稍后再试。")
 
+    @filter.command("老婆图鉴")
     async def show_personal_wife_gallery(self, event: AstrMessageEvent):
-        """展示个人老婆图鉴功能"""
+        """查看已经解锁的老婆"""
         group_id = event.message_obj.group_id
         if not group_id:
-            yield event.plain_result('该功能仅支持群聊，请在群聊中使用。')
+            yield event.plain_result("该功能仅支持群聊，请在群聊中使用。")
             return
 
         try:
             user_id = str(event.get_sender_id())
             nickname = event.get_sender_name() or "用户"
         except:
-            yield event.plain_result('无法获取用户信息，请重试。')
+            yield event.plain_result("无法获取用户信息，请重试。")
             return
 
         config = load_group_config(group_id)
         if str(user_id) not in config:
-            yield event.plain_result('你还没有解锁任何老婆哦~')
+            yield event.plain_result("你还没有解锁任何老婆哦~")
             return
 
         user_data = config[str(user_id)]
         unlocked_wives = get_wife_names_from_unlocked(user_data["unlocked"])
 
         if not unlocked_wives:
-            yield event.plain_result('你还没有解锁任何老婆哦~')
+            yield event.plain_result("你还没有解锁任何老婆哦~")
             return
 
         try:
             from .anime_wife_collage import create_personal_wife_gallery
         except Exception as e:
             print(f"加载个人图鉴模块失败: {e}")
-            yield event.plain_result('个人老婆图鉴功能加载失败，请稍后再试。')
+            yield event.plain_result("个人老婆图鉴功能加载失败，请稍后再试。")
             return
 
         loop = asyncio.get_event_loop()
-        personal_gallery_path = os.path.join(GALLERY_DIR, f'personal_gallery_{user_id}.png')
+        personal_gallery_path = os.path.join(
+            GALLERY_DIR, f"personal_gallery_{user_id}.png"
+        )
 
         try:
             personal_gallery_path = await loop.run_in_executor(
@@ -619,28 +665,29 @@ class WifePlugin(Star):
                 create_personal_wife_gallery,
                 unlocked_wives,
                 IMG_DIR,
-                personal_gallery_path
+                personal_gallery_path,
             )
 
             if not os.path.exists(personal_gallery_path):
-                yield event.plain_result('个人图鉴生成失败，未找到图片文件。')
+                yield event.plain_result("个人图鉴生成失败，未找到图片文件。")
                 return
 
-            with open(personal_gallery_path, 'rb') as f:
+            with open(personal_gallery_path, "rb") as f:
                 image_data = f.read()
 
-            msg = f'{nickname}，你的个人老婆图鉴来啦~ 已解锁: {len(unlocked_wives)}'
+            msg = f"{nickname}，你的个人老婆图鉴来啦~ 已解锁: {len(unlocked_wives)}"
             yield event.chain_result([Plain(msg), Image.fromBytes(image_data)])
 
         except Exception as e:
             print(f"生成个人图鉴失败: {e}")
-            yield event.plain_result('生成个人图鉴失败，请稍后再试。')
+            yield event.plain_result("生成个人图鉴失败，请稍后再试。")
+
 
 # 加载群配置数据，兼容旧格式
 def load_group_config(group_id: str):
-    filename = os.path.join(CONFIG_DIR, f'{group_id}.json')
+    filename = os.path.join(CONFIG_DIR, f"{group_id}.json")
     try:
-        with open(filename, encoding='utf-8') as f:
+        with open(filename, encoding="utf-8") as f:
             config = json.load(f)
             # 兼容旧格式数据
             for user_id in list(config.keys()):
@@ -653,28 +700,38 @@ def load_group_config(group_id: str):
                         old_nick = user_data[2] if len(user_data) > 2 else "用户"
                         config[user_id] = {
                             "current": {"wife_name": old_wife, "date": old_date},
-                            "unlocked": [{"wife_name": old_wife, "unlock_date": old_date}],
-                            "nickname": old_nick
+                            "unlocked": [
+                                {"wife_name": old_wife, "unlock_date": old_date}
+                            ],
+                            "nickname": old_nick,
                         }
                 else:
                     # 检查 unlocked 格式是否需要升级
-                    if "unlocked" in user_data and isinstance(user_data["unlocked"], list):
-                        if user_data["unlocked"] and isinstance(user_data["unlocked"][0], str):
+                    if "unlocked" in user_data and isinstance(
+                        user_data["unlocked"], list
+                    ):
+                        if user_data["unlocked"] and isinstance(
+                            user_data["unlocked"][0], str
+                        ):
                             # 升级旧格式的 unlocked 列表
-                            user_data["unlocked"] = upgrade_unlocked_format(user_data["unlocked"])
+                            user_data["unlocked"] = upgrade_unlocked_format(
+                                user_data["unlocked"]
+                            )
             return config
     except Exception as e:
         print(f"加载群配置失败: {e}")
         return {}
 
+
 # 写入群配置数据
 def write_group_config(group_id: str, config: dict):
-    config_file = os.path.join(CONFIG_DIR, f'{group_id}.json')
+    config_file = os.path.join(CONFIG_DIR, f"{group_id}.json")
     try:
-        with open(config_file, 'w', encoding='utf-8') as f:
+        with open(config_file, "w", encoding="utf-8") as f:
             json.dump(config, f, ensure_ascii=False, indent=2)
     except Exception as e:
         print(f"保存群配置失败: {e}")
+
 
 # 程序启动时加载NTR数据
 load_ntr_data()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: astrbot_plugin_AnimeWife # 这是你的插件的唯一识别名。
-desc: 群老婆插件。 # 插件简短描述
-version: v1.5.2 # 插件版本号。格式：v1.1.1 或者 v1.1
+desc: 群老婆插件 # 插件简短描述
+version: v1.5.3 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: 长安某 # 作者
 repo: https://github.com/zgojin/zgojin-zgojin-astrbot_plugin_AW # 插件的仓库地址


### PR DESCRIPTION
使用Astrbot自带的@filter.command适配器、弃用 on_all_messages 方法的命令匹配循环，让代码格式与使用更简洁方便与更具维护性，以及可以展示指令列表：
<img width="381" height="103" alt="20250804221710318" src="https://github.com/user-attachments/assets/9af443a8-ffd6-473d-b42d-4e8f23b60389" />

指令帮助列表可在Astrbot插件界面查看：
<img width="877" height="357" alt="20250804220748032" src="https://github.com/user-attachments/assets/00c71c9c-a44e-4de1-8985-a63cf29bd7fd" />
以及可以配合plugin_help插件等在“/帮助“列表中查看：
<img width="872" height="234" alt="20250804221237631" src="https://github.com/user-attachments/assets/0fb9ec7a-1039-479a-bc99-68097f07e602" />

美化README：
<img width="591" height="128" alt="20250804220716732" src="https://github.com/user-attachments/assets/354b363f-1a42-45cb-8cc2-aabdb3c44ff9" />
<img width="392" height="252" alt="20250804220721942" src="https://github.com/user-attachments/assets/62bbcaed-076d-461a-a2a8-06a8f036149a" />
<img width="248" height="83" alt="20250804220727608" src="https://github.com/user-attachments/assets/b68575f6-2b06-422e-baad-ed93e9c6f3c2" />

为规避可能存在的暴力元素，将“抽老婆”指令更改为“抽取老婆”
版本提升至1.5.3